### PR TITLE
Quick design hotfixes 

### DIFF
--- a/src/main/java/experiments/ClassifierLists.java
+++ b/src/main/java/experiments/ClassifierLists.java
@@ -29,6 +29,7 @@ import timeseriesweka.classifiers.ensembles.elastic_ensemble.WDTW1NN;
 import timeseriesweka.classifiers.proximityForest.ProximityForestWeka;
 import vector_classifiers.CAWPE;
 import vector_classifiers.PLSNominalClassifier;
+import vector_classifiers.TunedXGBoost;
 import weka.classifiers.Classifier;
 import weka.classifiers.bayes.BayesNet;
 import weka.classifiers.bayes.NaiveBayes;
@@ -84,7 +85,18 @@ public class ClassifierLists {
     public static Classifier setClassifierClassic(String classifier, int fold){
         Classifier c=null;
         switch(classifier){
-            
+            case "XGBoostMultiThreaded":
+                c = new TunedXGBoost(); 
+                break;
+            case "XGBoost":
+                c = new TunedXGBoost(); 
+                ((TunedXGBoost)c).setRunSingleThreaded(true);
+                break;
+            case "SmallTunedXGBoost":
+                c = new TunedXGBoost(); 
+                ((TunedXGBoost)c).setRunSingleThreaded(true);
+                ((TunedXGBoost)c).setSmallParaSearchSpace_64paras();
+                break;
             case "ProximityForest":
                 c = new ProximityForestWeka();
                 break;            

--- a/src/main/java/experiments/Experiments.java
+++ b/src/main/java/experiments/Experiments.java
@@ -432,11 +432,16 @@ public class Experiments  {
         
             //If needed, build/make the directory to write the train and/or testFold files to
             if (expSettings.supportingFilePath == null || expSettings.supportingFilePath.equals(""))
-                expSettings.supportingFilePath = fullWriteLocation + "fold" + expSettings.foldId + "/";
+                expSettings.supportingFilePath = fullWriteLocation;
+            
+            ///////////// 02/04/2019 jamesl to be put back in in place of above when interface redesign finished. 
+            // default builds a foldx/ dir in normal write dir
+//            if (expSettings.supportingFilePath == null || expSettings.supportingFilePath.equals(""))
+//                expSettings.supportingFilePath = fullWriteLocation + "fold" + expSettings.foldId + "/";
 //            if (classifier instanceof FileProducer) {
-                f = new File(expSettings.supportingFilePath);
-                if (!f.exists())
-                    f.mkdirs();
+//                f = new File(expSettings.supportingFilePath);
+//                if (!f.exists())
+//                    f.mkdirs();
 //            }
             
             //If this is to be a single _parameter_ evaluation of a fold, check whether this exists, and again quit if it does.

--- a/src/main/java/vector_classifiers/TunedClassifier.java
+++ b/src/main/java/vector_classifiers/TunedClassifier.java
@@ -89,6 +89,7 @@ public class TunedClassifier extends AbstractClassifier
     
     
     public TunedClassifier() { 
+        this.tuner = new Tuner(); 
     }
     
     public TunedClassifier(AbstractClassifier classifier, ParameterSpace space) { 


### PR DESCRIPTION
default supporting dir creation removed, initially put in pre-empting interface changes. xgbosot on classifier lists, tuner built by default in tunedclassifier