### PR TITLE
CAWPE missing-dists-replacement functionality

### DIFF
--- a/src/main/java/evaluation/storage/ClassifierResults.java
+++ b/src/main/java/evaluation/storage/ClassifierResults.java
@@ -1026,6 +1026,22 @@ public class ClassifierResults implements DebugPrinting, Serializable{
         return timeUnit.toNanos(getPredictionTime(index)); 
     }
     
+    public ArrayList<String> getPredDescriptions() {
+        return predDescriptions;
+    }
+    
+    public String[] getPredDescriptionsAsArray() {
+        String[] ds=new String[predDescriptions.size()];
+        int i=0;
+        for(String d:predDescriptions)
+            ds[i++]=d;
+        return ds;
+    }
+    
+    public String getPredDescription(int index) {
+        return predDescriptions.get(index);
+    }
+    
     public void cleanPredictionInfo() {
         predDistributions = null;
         predClassValues = null;


### PR DESCRIPTION
Hacky case to replace missing dists in individual classifiers' saved results with one hot vectors, turned on by a flag setter, default off (i.e. will fail if any saved results are missing dists) 

Pred description getters added to classifier results too, they were apparently missing