### PR TITLE
Adjusted travis to jdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+jdk:
+  - openjdk8
 branches:
   only:
   - gh-pages


### PR DESCRIPTION
Fixes the build compilation on travis due to weka not supporting jdk 11 (we have an old weka version)