### PR TITLE
Experiments/classifierResults trainEstimate method update

### DIFF
--- a/src/main/java/evaluation/storage/ClassifierResults.java
+++ b/src/main/java/evaluation/storage/ClassifierResults.java
@@ -216,6 +216,30 @@ public class ClassifierResults implements DebugPrinting, Serializable{
      */
     private long memoryUsage = -1; 
  
+    
+    /**
+     * todo initially intended as a temporary measure, but might stay here until a switch 
+     * over to json etc is made
+     * 
+     * See the experiments parameter trainEstimateMethod
+     * 
+     * This defines the method and parameter of train estimate used, if one was done
+     */
+    private String errorEstimateMethod = "";
+    
+    /**
+     * todo initially intended as a temporary measure, but might stay here until a switch 
+     * over to json etc is made
+     * 
+     * This defines the total time taken to estimate the classifier's error. This currently 
+     * does not mean anything for classifiers implementing the TrainAccuracyEstimate interface,
+     * and as such would need to set this themselves (but likely do not)
+     * 
+     * For those classifiers that do not implement that, Experiments.findOrSetupTrainEstimate(...) will set this value
+     * as a wrapper around the entire evaluate call for whichever errorEstimateMethod is being used
+     */
+    private long errorEstimateTime = -1;
+    
 //REMAINDER OF THE FILE - 1 prediction per line
     //raw performance data. currently just four parallel arrays
     private ArrayList<Double> trueClassValues;
@@ -768,7 +792,63 @@ public class ClassifierResults implements DebugPrinting, Serializable{
     public void setBenchmarkTime(long benchmarkTime) {
         this.benchmarkTime = benchmarkTime;
     }
+
+    /**
+     * todo initially intended as a temporary measure, but might stay here until a switch 
+     * over to json etc is made
+     * 
+     * See the experiments parameter trainEstimateMethod
+     * 
+     * This defines the method and parameter of train estimate used, if one was done
+     */
+    public String getErrorEstimateMethod() {
+        return errorEstimateMethod;
+    }
+
+    /**
+     * todo initially intended as a temporary measure, but might stay here until a switch 
+     * over to json etc is made
+     * 
+     * See the experiments parameter trainEstimateMethod
+     * 
+     * This defines the method and parameter of train estimate used, if one was done
+     */
+    public void setErrorEstimateMethod(String errorEstimateMethod) {
+        this.errorEstimateMethod = errorEstimateMethod;
+    }
+
+    /**
+     * todo initially intended as a temporary measure, but might stay here until a switch 
+     * over to json etc is made
+     * 
+     * This defines the total time taken to estimate the classifier's error. This currently 
+     * does not mean anything for classifiers implementing the TrainAccuracyEstimate interface,
+     * and as such would need to set this themselves (but likely do not)
+     * 
+     * For those classifiers that do not implement that, Experiments.findOrSetupTrainEstimate(...) will set this value
+     * as a wrapper around the entire evaluate call for whichever errorEstimateMethod is being used
+     */
+    public long getErrorEstimateTime() {
+        return errorEstimateTime;
+    }
+
+    /**
+     * todo initially intended as a temporary measure, but might stay here until a switch 
+     * over to json etc is made
+     * 
+     * This defines the total time taken to estimate the classifier's error. This currently 
+     * does not mean anything for classifiers implementing the TrainAccuracyEstimate interface,
+     * and as such would need to set this themselves (but likely do not)
+     * 
+     * For those classifiers that do not implement that, Experiments.findOrSetupTrainEstimate(...) will set this value
+     * as a wrapper around the entire evaluate call for whichever errorEstimateMethod is being used
+     */
+    public void setErrorEstimateTime(long errorEstimateTime) {
+        this.errorEstimateTime = errorEstimateTime;
+    }
            
+    
+    
 
     /****************************
      *   
@@ -1461,6 +1541,10 @@ public class ClassifierResults implements DebugPrinting, Serializable{
             memoryUsage = Long.parseLong(parts[4]);
         if (parts.length > 5) 
             numClasses = Integer.parseInt(parts[5]);
+        if (parts.length > 6) 
+            errorEstimateMethod = parts[6];
+        if (parts.length > 7) 
+            errorEstimateTime = Long.parseLong(parts[7]);
         
         return acc;
     }
@@ -1470,7 +1554,10 @@ public class ClassifierResults implements DebugPrinting, Serializable{
             + "," + testTime
             + "," + benchmarkTime
             + "," + memoryUsage
-            + "," + numClasses();
+            + "," + numClasses()
+            + "," + errorEstimateMethod
+            + "," + errorEstimateTime;
+        
         return res;
     }
 

--- a/src/main/java/evaluation/storage/ClassifierResults.java
+++ b/src/main/java/evaluation/storage/ClassifierResults.java
@@ -1888,7 +1888,7 @@ public class ClassifierResults implements DebugPrinting, Serializable{
         
         int mid = copy.size()/2;
         if (copy.size() % 2 == 0)
-            return (copy.get(mid) + copy.get(mid+1)) / 2;
+            return (copy.get(mid) + copy.get(mid-1)) / 2;
         else 
             return copy.get(mid);
     }

--- a/src/main/java/experiments/Experiments.java
+++ b/src/main/java/experiments/Experiments.java
@@ -677,7 +677,7 @@ public class Experiments  {
                     throw new Exception("Unrecognised method to estimate error on the train given: " + exp.trainEstimateMethod);
             }
             
-            long estimateTime = estimateTimeStart - System.nanoTime();
+            long estimateTime = System.nanoTime() - estimateTimeStart;
                     
             trainResults.setErrorEstimateMethod(exp.trainEstimateMethod);
             trainResults.setErrorEstimateTime(estimateTime);

--- a/src/main/java/experiments/Experiments.java
+++ b/src/main/java/experiments/Experiments.java
@@ -476,56 +476,6 @@ public class Experiments  {
     }
     
     /**
-     * If the dataset loaded has a first attribute whose name _contains_ the string "experimentsSplitAttribute".toLowerCase() 
-     * then it will be assumed that we want to perform a leave out one X cross validation. Instances are sampled such that fold N is comprised of 
- a test set with all instances with first-attribute equal to the Nth unique value in a sorted list of first-attributes. The train
- set would be all other instances. The first attribute would then be removed from all instances, so that they are not given
- to the classifier to potentially learn from. It is up to the user to ensure the the foldID requested is within the range of possible 
- values 1 to numUniqueFirstAttValues
- 
- TODO: potentially just move to experiments.DatasetLists once we clean up that
-     * 
-     * @return new Instances[] { trainSet, testSet };
-     */
-    public static Instances[] splitDatasetByFirstAttribute(Instances all, int foldId) {        
-        TreeMap<Double, Integer> splitVariables = new TreeMap<>();
-        for (int i = 0; i < all.numInstances(); i++) {
-            //even if it's a string attribute, this val corresponds to the index into the array of possible strings for this att
-            double key= all.instance(i).value(0);
-            Integer val = splitVariables.get(key);
-            if (val == null)
-                val = 0;
-            splitVariables.put(key, ++val); 
-        }
-
-        //find the split attribute value to keep for testing this fold
-        double idToReserveForTestSet = -1;
-        int testSize = -1;
-        int c = 0;
-        for (Map.Entry<Double, Integer> splitVariable : splitVariables.entrySet()) {
-            if (c++ == foldId) {
-                idToReserveForTestSet = splitVariable.getKey();
-                testSize = splitVariable.getValue();
-            }
-        }
-
-        //make the split
-        Instances train = new Instances(all, all.size() - testSize);
-        Instances test  = new Instances(all, testSize);
-        for (int i = 0; i < all.numInstances(); i++)
-            if (all.instance(i).value(0) == idToReserveForTestSet)
-                test.add(all.instance(i));
-        train.addAll(all);
-
-        //delete the split attribute
-        train.deleteAttributeAt(0);
-        test.deleteAttributeAt(0);
-        
-        return new Instances[] { train, test };
-    }
-    
-        
-    /**
      * Perform an actual experiment, using the loaded classifier and resampled dataset given, writing to the specified results location. 
      * 
      * 1) If needed, set up file paths and flags related to a single parameter evaluation and/or the classifier's internal parameter saving things

--- a/src/main/java/experiments/Experiments.java
+++ b/src/main/java/experiments/Experiments.java
@@ -677,8 +677,6 @@ public class Experiments  {
                     throw new Exception("Unrecognised method to estimate error on the train given: " + exp.trainEstimateMethod);
             }
             
-            
-            
             long estimateTime = estimateTimeStart - System.nanoTime();
                     
             trainResults.setErrorEstimateMethod(exp.trainEstimateMethod);


### PR DESCRIPTION
Quick implementation of a parameter/method to select what the method of estimating error on the train should be, and storing that info +the full time of the estimate by itself in classifierResults

notes: 
* Classifiers that implement TrainAccuracyEstimate (i.e. produce their own train results) obviously wont be setting that information. Experiments will set this info (at the end of line 3) for all other classifiers
* Found/fixed a bug in classifierresults medianPredTime, for even-numbers of predictions it was returning the median+2'th time, not the median's. Practically speaking, old timings are not 'broken' by any means, well within the variance of a particular prediction anyway
* Currently available to select is crossvalidation and a number of folds (specified by cv_10 for e.g cv with 10 folds, the default as it has always been), and a single held out validation set, i.e. a random split of the train set by some proportion (e.g hov_0.7). In either case, as always, the classifier is always finally re-trained on the full train set for testing